### PR TITLE
Bind to the data subfolder of the postgres container for FedLCM docker-compose deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
   postgres:
     image: postgres:13.3
     volumes:
-      - ./output/data/postgres:/var/lib/postgresql
+      - ./output/data/postgres:/var/lib/postgresql/data
     ports:
       - "5432:5432"
     restart: always


### PR DESCRIPTION

The postgres image has a Volume item pointing to `/var/lib/postgresql/data`. If we don't explicitly bind this path, a volume will be automatically created by docker. And it will be destroyed after `docker-compose down`, causing data loss.

To address that, we explicitly use a host folder to bind to this path.
